### PR TITLE
chore: Remove "client" from metrics names

### DIFF
--- a/src/metrics_utils.rs
+++ b/src/metrics_utils.rs
@@ -8,10 +8,10 @@ pub const CLOSED_TOTAL: &str = "mobc_pool_connections_closed_total";
 pub const OPEN_CONNECTIONS: &str = "mobc_pool_connections_open";
 pub const ACTIVE_CONNECTIONS: &str = "mobc_pool_connections_busy";
 pub const IDLE_CONNECTIONS: &str = "mobc_pool_connections_idle";
-pub const WAIT_COUNT: &str = "mobc_client_queries_wait";
+pub const WAIT_COUNT: &str = "mobc_queries_wait";
 
 // histogram
-pub const WAIT_DURATION: &str = "mobc_client_queries_wait_histogram_ms";
+pub const WAIT_DURATION: &str = "mobc_queries_wait_histogram_ms";
 
 pub fn describe_metrics() {
     describe_counter!(OPENED_TOTAL, "Total number of Pool Connections opened");


### PR DESCRIPTION
In mobc context, the queries can just be called "queries", not "client_queries". (This might be a leftover from adopting this code from Prisma).

(This is a breaking change, so maybe not actually worth it - feel free to just close the PR then.)